### PR TITLE
Aggregate prefix registration

### DIFF
--- a/ndn_python_repo/handle/delete_command_handle.py
+++ b/ndn_python_repo/handle/delete_command_handle.py
@@ -44,7 +44,7 @@ class DeleteCommandHandle(CommandHandle):
         self.pb.subscribe(self.prefix + ['delete'], self._on_delete_msg)
 
         # listen on delete check interests
-        self.app.route(self.prefix + ['delete check'])(self._on_check_interest)
+        self.app.set_interest_filter(self.prefix + ['delete check'], self._on_check_interest)
 
     def _on_delete_msg(self, msg):
         try:

--- a/ndn_python_repo/handle/write_command_handle.py
+++ b/ndn_python_repo/handle/write_command_handle.py
@@ -44,7 +44,7 @@ class WriteCommandHandle(CommandHandle):
         self.pb.subscribe(self.prefix + ['insert'], self._on_insert_msg)
 
         # listen on insert check interests
-        self.app.route(self.prefix + ['insert check'])(self._on_check_interest)
+        self.app.set_interest_filter(self.prefix + ['insert check'], self._on_check_interest)
 
     def _on_insert_msg(self, msg):
         try:

--- a/ndn_python_repo/repo.py
+++ b/ndn_python_repo/repo.py
@@ -37,6 +37,8 @@ class Repo(object):
 
         # Init PubSub
         self.write_handle.pb.set_publisher_prefix(self.prefix)
+        self.write_handle.pb.set_base_prefix(self.prefix)
+        self.delete_handle.pb.set_base_prefix(self.prefix)
         await self.write_handle.pb.wait_for_ready()
 
         await self.write_handle.listen(self.prefix)


### PR DESCRIPTION
This PR forces the repo only registering the aggregated repo prefix rather individual write and delete handles.

For example, if the repo is configured with name `/ndn/edu/ucla/python-repo`, the existing implementation makes repo register `/ndn/edu/ucla/python-repo/insert`, `/ndn/edu/ucla/python-repo/delete`, `/ndn/edu/ucla/python-repo/insert%20check`, and `/ndn/edu/ucla/python-repo/delete%20check`.
This PR forces the repo only registering aggregated prefix `/ndn/edu/ucla/python-repo` to NFD and registering other prefixes as internal Interest filters.