### PR TITLE
code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,6 @@ venv.bak/
 **/.DS_Store
 .vscode/
 .leveldb/
-.pytest_cache/
 repo.db
 NDN_Repo.egg-info/
 

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -112,3 +112,4 @@ To run ndn-python-repo with systemd on Linux, perform the following steps:
 #. Examine logs::
 
     $ sudo journalctl -u ndn-python-repo.service
+

--- a/docs/src/misc_pkgs/client_side.rst
+++ b/docs/src/misc_pkgs/client_side.rst
@@ -10,7 +10,7 @@ There are four parts:
 
 #. **PutfileClient**: insert files into the repo.
 #. **GetfileClient**: get files from the repo.
-#. **DeleteClient**: detele data packets from the repo.
+#. **DeleteClient**: delete data packets from the repo.
 #. **CommandChecker**: check process status from the repo.
 
 The example programs in :mod:`examples/` illustrate how to use these packages.

--- a/docs/src/misc_pkgs/pub_sub.rst
+++ b/docs/src/misc_pkgs/pub_sub.rst
@@ -21,7 +21,7 @@ Process
 
 Under the hood the ``PubSub`` module transmits a series of Interest and Data packets:
 
-1. The subscriber calls ``subscribe(topic, cb)``. This makes the subcriber listen on
+1. The subscriber calls ``subscribe(topic, cb)``. This makes the subscriber listen on
 ``"/<topic>/notify"``.
 
 2. The publisher invokes ``publish(topic, msg)``. This method sends an Interest with name

--- a/docs/src/specification/security.rst
+++ b/docs/src/specification/security.rst
@@ -20,7 +20,7 @@ Required Settings
 
 .. warning::
   Unfortunately current implementation does not follow these requirements by default.
-  This may cause some potential vulnerbilities. Will be fixed in future versions.
+  This may cause some potential vulnerabilities. Will be fixed in future versions.
 
 
 Recommended Settings
@@ -31,7 +31,7 @@ Recommended Settings
 
   - Since there is no replay attack, the Repo does not have to remember the list of ``SignatureNonce``.
 
-- If the Repo is provided as a network service, the certifcate obtained from the network provider should be used.
+- If the Repo is provided as a network service, the certificate obtained from the network provider should be used.
   In this case, the prefix registration command and repo's publication data are signed using the same key.
 
   - For example, if one employs a Repo as a public service of NDN testbed,

--- a/examples/command_checker.py
+++ b/examples/command_checker.py
@@ -6,11 +6,9 @@
 """
 
 import argparse
-import asyncio as aio
 import logging
 from ndn.app import NDNApp
 from ndn.encoding import Name
-from ndn.security import KeychainDigest
 from ndn_python_repo.clients import CommandChecker
 
 

--- a/examples/delfile.py
+++ b/examples/delfile.py
@@ -6,11 +6,9 @@
 """
 
 import argparse
-import asyncio as aio
 import logging
 from ndn.app import NDNApp
 from ndn.encoding import Name
-from ndn.security import KeychainDigest
 from ndn_python_repo.clients import DeleteClient
 
 
@@ -61,7 +59,7 @@ def main():
     # process default values
     start_block_id = int(args.start_block_id) if args.start_block_id else None
     end_block_id = int(args.end_block_id) if args.end_block_id else None
-    if args.register_prefix == None:
+    if args.register_prefix is None:
         args.register_prefix = args.name_at_repo
     args.register_prefix = Name.from_str(args.register_prefix)
 

--- a/examples/getfile.py
+++ b/examples/getfile.py
@@ -6,11 +6,9 @@
 """
 
 import argparse
-import asyncio as aio
 import logging
 from ndn.app import NDNApp
 from ndn.encoding import Name
-from ndn.security import KeychainDigest
 from ndn_python_repo.clients import GetfileClient
 
 

--- a/examples/leavesync.py
+++ b/examples/leavesync.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python3
 import argparse
 import logging
 from ndn.app import NDNApp
 from ndn.encoding import Name
 from ndn.security import KeychainDigest
 from ndn_python_repo.clients import SyncClient
-import uuid
 
 async def run_leave_sync_client(app: NDNApp, **kwargs):
     client = SyncClient(app=app, prefix=kwargs['client_prefix'], repo_name=kwargs['repo_name'])

--- a/examples/publisher.py
+++ b/examples/publisher.py
@@ -22,7 +22,7 @@ async def run_publisher(app: NDNApp, publisher_prefix: NonStrictName):
     msg = f'pubsub message generated at {str(datetime.datetime.now())}'.encode()
     await pb.publish(topic, msg)
 
-    # wait for msg to be fetched by subsciber
+    # wait for msg to be fetched by subscriber
     await aio.sleep(10)
     app.shutdown()
 

--- a/examples/putfile.py
+++ b/examples/putfile.py
@@ -6,7 +6,6 @@
 """
 
 import argparse
-import asyncio as aio
 import logging
 import multiprocessing
 from ndn.app import NDNApp
@@ -72,7 +71,7 @@ def main():
                         level=logging.INFO)
 
     # ``register_prefix`` is by default identical to ``name_at_repo``
-    if args.register_prefix == None:
+    if args.register_prefix is None:
         args.register_prefix = args.name_at_repo
     args.register_prefix = Name.from_str(args.register_prefix)
     if args.forwarding_hint:

--- a/examples/subscriber.py
+++ b/examples/subscriber.py
@@ -6,7 +6,6 @@
     @Date   2020-05-10
 """
 
-import asyncio as aio
 import logging
 from ndn.app import NDNApp
 from ndn.encoding import Name, NonStrictName

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -5,7 +5,6 @@ from ndn.app import NDNApp
 from ndn.encoding import Name
 from ndn.security import KeychainDigest
 from ndn_python_repo.clients import SyncClient
-import uuid
 
 
 async def run_sync_client(app: NDNApp, **kwargs):

--- a/ndn_python_repo/clients/delete.py
+++ b/ndn_python_repo/clients/delete.py
@@ -9,14 +9,13 @@ import os
 import sys
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
-import argparse
 import asyncio as aio
 from ..command import RepoCommandParam, ObjParam, EmbName, RepoStatCode
 from .command_checker import CommandChecker
 from ..utils import PubSub
 import logging
 from ndn.app import NDNApp
-from ndn.encoding import Name, Component, DecodeError, NonStrictName
+from ndn.encoding import Name, NonStrictName
 from typing import Optional
 from hashlib import sha256
 
@@ -46,7 +45,7 @@ class DeleteClient(object):
         :param prefix: NonStrictName. The name of the file stored in the remote repo.
         :param start_block_id: int. Default value is 0.
         :param end_block_id: int. If not specified, repo will attempt to delete all data packets\
-            with segment number starting from `start_block_id` continously.
+            with segment number starting from `start_block_id` continuously.
         :param register_prefix: If repo is configured with ``register_root=False``, it unregisters\
             ``register_prefix`` after receiving the deletion command.
         :param check_prefix: NonStrictName. The repo will publish process check messages under\
@@ -89,9 +88,10 @@ class DeleteClient(object):
 
         :param check_prefix: NonStrictName. The prefix under which the check message will be\
             published.
-        :param process_id: int. The process id to check for delete process
+        :param request_no: int. The request number to check for delete process (formerly process id)
         :return: Number of deleted packets.
         """
+        # fixme: why is check_prefix never used?
         checker = CommandChecker(self.app)
         n_retries = 3
         while n_retries > 0:

--- a/ndn_python_repo/clients/putfile.py
+++ b/ndn_python_repo/clients/putfile.py
@@ -106,7 +106,7 @@ class PutfileClient(object):
         self.logger.info(f'On interest: {Name.to_str(int_name)}')
         seq = Component.to_number(int_name[-1])
         name_wo_seq = Name.to_str(int_name[:-1])
-        if name_wo_seq in self.encoded_packets and seq >= 0 and seq < len(self.encoded_packets[name_wo_seq]):
+        if name_wo_seq in self.encoded_packets and 0 <= seq < len(self.encoded_packets[name_wo_seq]):
             encoded_packets = self.encoded_packets[name_wo_seq]
             self.app.put_raw_packet(encoded_packets[seq])
             self.logger.info(f'Serve data: {Name.to_str(int_name)}')
@@ -188,9 +188,10 @@ class PutfileClient(object):
 
         :param check_prefix: NonStrictName. The prefix under which the check message will be\
             published.
-        :param process_id: int. The process id to check.
-        :return: number of inserted packets.
+        :param request_no: bytes. The request number to check.
+        :return: int number of inserted packets.
         """
+        # fixme: why is check_prefix not used?
         checker = CommandChecker(self.app)
         n_retries = 5
         while n_retries > 0:

--- a/ndn_python_repo/clients/sync.py
+++ b/ndn_python_repo/clients/sync.py
@@ -10,18 +10,14 @@ import os
 import sys
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
-import asyncio as aio
-from .command_checker import CommandChecker
-from ..command import RepoCommandParam, SyncParam, EmbName, RepoStatCode
+from ..command import RepoCommandParam, SyncParam
 from ..utils import PubSub
 import logging
-import multiprocessing
 from ndn.app import NDNApp
-from ndn.encoding import Name, NonStrictName, Component, Links
+from ndn.encoding import Name, NonStrictName
 import os
 import platform
 from hashlib import sha256
-from typing import Optional, List
 
 class SyncClient(object):
 

--- a/ndn_python_repo/cmd/install.py
+++ b/ndn_python_repo/cmd/install.py
@@ -1,8 +1,6 @@
-import os
 import platform
 import shutil
 import sys
-# from pkg_resources import resource_filename
 import importlib.resources
 
 

--- a/ndn_python_repo/cmd/main.py
+++ b/ndn_python_repo/cmd/main.py
@@ -1,11 +1,8 @@
 import argparse
-import asyncio as aio
 import logging
-# import pkg_resources
 import importlib.metadata
 import sys
 from ndn.app import NDNApp
-from ndn.encoding import Name
 from ndn_python_repo import *
 
 
@@ -43,7 +40,7 @@ def process_config(cmdline_args):
     Read and process config file. Some config options are overridden by cmdline args.
     """
     config = get_yaml(cmdline_args.config)
-    if cmdline_args.repo_name != None:
+    if cmdline_args.repo_name is not None:
         config['repo_config']['repo_name'] = cmdline_args.repo_name
     return config
 

--- a/ndn_python_repo/cmd/port.py
+++ b/ndn_python_repo/cmd/port.py
@@ -1,6 +1,7 @@
+# noinspection GrazieInspection
 """
     This script ports sqlite db file from repo-ng to ndn-python-repo.
-    It takes as input a repo-ng sqlite database file, traverse the database and inserts data to
+    It takes as input a repo-ng sqlite database file, traverses the database, and inserts data into
     an ndn-python-repo using TCP bulk insertion.
 
     @Author jonnykong@cs.ucla.edu
@@ -12,7 +13,7 @@ import asyncio as aio
 import os
 import sqlite3
 import sys
-from ndn.encoding import Name, Component, ndn_format_0_3, tlv_var
+from ndn.encoding import Name, ndn_format_0_3, tlv_var
 
 
 def create_sqlite3_connection(db_file):
@@ -71,9 +72,9 @@ def main() -> int:
                         required=True, help='Port of python repo')
     args = parser.parse_args()
 
-    if args.addr == None:
+    if args.addr is None:
         args.addr = '127.0.0.1'
-    if args.port == None:
+    if args.port is None:
         args.addr = '7376'
     
     src_db_file = os.path.expanduser(args.dbfile)

--- a/ndn_python_repo/handle/read_handle.py
+++ b/ndn_python_repo/handle/read_handle.py
@@ -32,7 +32,7 @@ class ReadHandle(object):
     
     def unlisten(self, prefix):
         """
-        :param name: NonStrictName.
+        :param prefix: NonStrictName.
         """
         aio.ensure_future(self.app.unregister(prefix))
         self.logger.info(f'Read handle: stop listening to {Name.to_str(prefix)}')
@@ -44,7 +44,7 @@ class ReadHandle(object):
         logging.debug(f'Repo got Interest with{"out" if not int_param.must_be_fresh else ""} '
                       f'MustBeFresh flag set for name {Name.to_str(int_name)}')
         data_bytes = self.storage.get_data_packet(int_name, int_param.can_be_prefix, int_param.must_be_fresh)
-        if data_bytes == None:
+        if data_bytes is None:
             return
         self.app.put_raw_packet(data_bytes)
         self.logger.info(f'Read handle: serve data {Name.to_str(int_name)}')

--- a/ndn_python_repo/handle/utils.py
+++ b/ndn_python_repo/handle/utils.py
@@ -1,8 +1,8 @@
-from typing import Tuple, Optional
+from typing import Optional
 from ..command import ObjParam
 
 
-def normalize_block_ids(obj: ObjParam) -> Tuple[bool, Optional[int], Optional[int]]:
+def normalize_block_ids(obj: ObjParam) -> tuple[bool, Optional[int], Optional[int]]:
     """
     Normalize insert parameter, or reject the param if it's invalid.
     :param obj: The object to fetch.
@@ -11,7 +11,7 @@ def normalize_block_ids(obj: ObjParam) -> Tuple[bool, Optional[int], Optional[in
     start_id = obj.start_block_id
     end_id = obj.end_block_id
 
-    # Valid if neither start_block_id or end_block_id is given, fetch single data without seg number
+    # Valid if neither start_block_id nor end_block_id is given, fetch single data without seg number
     if start_id is None and end_id is None:
         return True, None, None
 

--- a/ndn_python_repo/storage/leveldb.py
+++ b/ndn_python_repo/storage/leveldb.py
@@ -1,25 +1,25 @@
 import os
 import pickle
-import plyvel
+import plyvel # fixme: my ide tells me this doesn't exist
 from .storage_base import Storage
-from typing import List, Optional
+from typing import Optional
 
 
 class LevelDBStorage(Storage):
 
-    def __init__(self, dir: str):
+    def __init__(self, level_dir: str):
         """
         Creates a LevelDB storage instance at disk location ``str``.
 
-        :param dir: str. The disk location of the database directory.
+        :param level_dir: str. The disk location of the database directory.
         """
         super().__init__()
-        db_dir = os.path.expanduser(dir)
+        db_dir = os.path.expanduser(level_dir)
         if not os.path.exists(db_dir):
             try:
                 os.makedirs(db_dir)
             except PermissionError:
-                raise PermissionError(f'Could not create database directory: {db_path}') from None
+                raise PermissionError(f'Could not create database directory: {db_dir}') from None
         self.db = plyvel.DB(db_dir, create_if_missing=True)
 
     def _put(self, key: bytes, value: bytes, expire_time_ms: int=None):
@@ -33,30 +33,30 @@ class LevelDBStorage(Storage):
         """
         self.db.put(key, pickle.dumps((value, expire_time_ms)))
 
-    def _put_batch(self, keys: List[bytes], values: List[bytes], expire_time_mss:List[Optional[int]]):
+    def _put_batch(self, keys: list[bytes], values: list[bytes], expire_time_mss:list[Optional[int]]):
         """
         Batch insert.
 
-        :param key: List[bytes].
-        :param value: List[bytes].
-        :param expire_time_ms: List[Optional[int]]. The expiration time for each data in ``value``.
+        :param keys: list[bytes].
+        :param values: list[bytes].
+        :param expire_time_mss: list[Optional[int]]. The expiration time for each data in ``value``.
         """
         with self.db.write_batch() as b:
             for key, value, expire_time_ms in zip(keys, values, expire_time_mss):
                 b.put(key, pickle.dumps((value, expire_time_ms)))
 
-    def _get(self, key: bytes, can_be_prefix=False, must_be_fresh=False) -> bytes:
+    def _get(self, key: bytes, can_be_prefix=False, must_be_fresh=False) -> bytes | None:
         """
         Get value from levelDB.
 
         :param key: bytes.
         :param can_be_prefix: bool. If true, use prefix match instead of exact match.
         :param must_be_fresh: bool. If true, ignore expired data.
-        :return: The value of the data packet.
+        :return: bytes. The value of the data packet in bytes or None if it can't be found or is not fresh when must_be_fresh is True.
         """
         if not can_be_prefix:
             record = self.db.get(key)
-            if record == None:
+            if record is None:
                 return None
             value, expire_time_ms = pickle.loads(record)
             if not must_be_fresh or expire_time_ms is not None and expire_time_ms > self._time_ms():
@@ -77,7 +77,7 @@ class LevelDBStorage(Storage):
         :param key: bytes.
         :return: True if a data packet is being removed.
         """
-        if self._get(key) != None:
+        if self._get(key) is not None:
             self.db.delete(key)
             return True
         else:

--- a/ndn_python_repo/storage/mongodb.py
+++ b/ndn_python_repo/storage/mongodb.py
@@ -1,8 +1,7 @@
 import base64
-import pymongo
 from pymongo import MongoClient, ReplaceOne
 from .storage_base import Storage
-from typing import List, Optional
+from typing import Optional
 
 
 class MongoDBStorage(Storage):
@@ -47,13 +46,13 @@ class MongoDBStorage(Storage):
         }
         self.c_collection.replace_one({'key': key}, replace, upsert=True)
 
-    def _put_batch(self, keys: List[bytes], values: List[bytes], expire_time_mss:List[Optional[int]]):
+    def _put_batch(self, keys: list[bytes], values: list[bytes], expire_time_mss:list[Optional[int]]):
         """
         Batch insert.
 
-        :param key: List[bytes].
-        :param value: List[bytes].
-        :param expire_time_ms: List[Optional[int]]. The expiration time for each data in ``value``.
+        :param keys: list[bytes].
+        :param values: list[bytes].
+        :param expire_time_mss: list[Optional[int]]. The expiration time for each data in ``value``.
         """
         keys = [base64.b16encode(key).decode() for key in keys]
         replaces = []

--- a/ndn_python_repo/storage/sqlite.py
+++ b/ndn_python_repo/storage/sqlite.py
@@ -1,6 +1,6 @@
 import os
 import sqlite3
-from typing import List, Optional
+from typing import Optional
 from .storage_base import Storage
 
 
@@ -45,13 +45,13 @@ class SqliteStorage(Storage):
             (key, value, expire_time_ms))
         self.conn.commit()
 
-    def _put_batch(self, keys: List[bytes], values: List[bytes], expire_time_mss:List[Optional[int]]):
+    def _put_batch(self, keys: list[bytes], values: list[bytes], expire_time_mss:list[Optional[int]]):
         """
         Batch insert.
 
-        :param key: List[bytes].
-        :param value: List[bytes].
-        :param expire_time_ms: List[Optional[int]]. The expiration time for each data in ``value``.
+        :param keys: list[bytes].
+        :param values: list[bytes].
+        :param expire_time_mss: list[Optional[int]]. The expiration time for each data in ``value``.
         """
         c = self.conn.cursor()
         c.executemany('INSERT OR REPLACE INTO data (key, value, expire_time_ms) VALUES (?, ?, ?)',

--- a/ndn_python_repo/storage/storage_base.py
+++ b/ndn_python_repo/storage/storage_base.py
@@ -6,7 +6,7 @@ from ndn.encoding.tlv_var import parse_tl_num
 from ndn.encoding import Name, Component, parse_data, NonStrictName
 from ndn.name_tree import NameTrie
 import time
-from typing import List, Optional
+from typing import Optional
 
 
 class Storage:
@@ -25,7 +25,7 @@ class Storage:
     def _put(self, key: bytes, data: bytes, expire_time_ms: int=None):
         raise NotImplementedError
 
-    def _put_batch(self, keys: List[bytes], values: List[bytes], expire_time_mss:List[Optional[int]]):
+    def _put_batch(self, keys: list[bytes], values: list[bytes], expire_time_mss:list[Optional[int]]):
         raise NotImplementedError
 
     def _get(self, key: bytes, can_be_prefix: bool=False, must_be_fresh: bool=False) -> bytes:

--- a/ndn_python_repo/storage/storage_factory.py
+++ b/ndn_python_repo/storage/storage_factory.py
@@ -42,7 +42,7 @@ def create_storage(config):
         else:
             raise NameError()
 
-    except NameError as exc:
+    except NameError:
         raise NotImplementedError(f'Unsupported database backend: {db_type}')
     
     return ret

--- a/ndn_python_repo/utils/concurrent_fetcher.py
+++ b/ndn_python_repo/utils/concurrent_fetcher.py
@@ -28,6 +28,7 @@ async def concurrent_fetcher(app: NDNApp, name: NonStrictName, start_id: int,
     :param start_id: int. The start number.
     :param end_id: Optional[int]. The end segment number. If not specified, continue fetching\
         until an interest receives timeout or nack or 3 times.
+    :param semaphore: aio.Semaphore. Semaphore used to fetch data.
     :return: Yield ``(FormalName, MetaInfo, Content, RawPacket)`` tuples in order.
     """
     name_conv = IdNamingConv.SEGMENT
@@ -57,15 +58,16 @@ async def concurrent_fetcher(app: NDNApp, name: NonStrictName, start_id: int,
         elif name_conv == IdNamingConv.SEQUENCE:
             int_name = name + [Component.from_sequence_num(seq)]
         elif name_conv == IdNamingConv.NUMBER:
+            # fixme: .from_number apparently requires a second parameter for "type"
             int_name = name + [Component.from_number(seq)]
         else:
-            logging.error('Unrecognized naming convetion')
+            logging.error('Unrecognized naming convention')
             return
         trial_times = 0
         while True:
             trial_times += 1
             # always retry when max_retries is -1
-            if max_retries >= 0 and trial_times > max_retries:
+            if 0 <= max_retries < trial_times:
                 semaphore.release()
                 is_failed = True
                 received_or_fail.set()
@@ -87,10 +89,10 @@ async def concurrent_fetcher(app: NDNApp, name: NonStrictName, start_id: int,
                     # cancel the Interests for non-existing data
                     for task in aio.all_tasks():
                         task_name = task.get_name()
-                        task_num = None
                         try:
                             task_num = int(task_name)
-                        except: continue
+                        except:
+                            continue
                         if task_num and task_num > final_id \
                             and task in tasks:
                             tasks.remove(task)
@@ -101,7 +103,7 @@ async def concurrent_fetcher(app: NDNApp, name: NonStrictName, start_id: int,
                 logging.info(f'Interest {Name.to_str(int_name)} nacked with reason={e.reason}')
             except InterestTimeout:
                 logging.info(f'Interest {Name.to_str(int_name)} timeout')
-            except InterestCanceled as e:
+            except InterestCanceled:
                 logging.info(f'Interest {Name.to_str(int_name)} (might legally) cancelled')
                 return
         semaphore.release()

--- a/ndn_python_repo/utils/passive_svs.py
+++ b/ndn_python_repo/utils/passive_svs.py
@@ -7,7 +7,7 @@
 
 import logging
 from base64 import b64decode, b64encode
-from typing import Dict, Callable
+from typing import Callable
 from ndn.app import NDNApp
 from ndn.app_support.svs import StateVecWrapper, SvsState
 from ndn.encoding import Name, NonStrictName, DecodeError, FormalName, BinaryStr, InterestParam, parse_interest, \
@@ -52,7 +52,7 @@ class PassiveSvs:
         states['inst_buffer'] = inst_buffer_enc
         return states
 
-    def decode_from_states(self, states: Dict):
+    def decode_from_states(self, states: dict):
         inst_buffer_dec = {}
         for nid, inst in states['inst_buffer'].items():
             inst_buffer_dec[nid] = b64decode(inst)
@@ -130,7 +130,7 @@ class PassiveSvs:
                     self.send_interest(raw_inst)
                 else: pass
 
-        # Notify remote there are mising nodes
+        # Notify remote there are missing nodes
         diff = self.local_sv.keys() - rsv_dict.keys()
         if len(diff) > 0:
             self.logger.info(f'Remote missing nodes: {list(diff)}')

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -23,20 +23,26 @@ port = 7377
 inline_cfg = f"""
 ---
 repo_config:
-  repo_name: '{repo_name}'
+  repo_name: {repo_name}
   register_root: {register_root}
 db_config:
-  db_type: 'sqlite3'
+  db_type: leveldb
   sqlite3:
-    'path': '{sqlite3_path}'
+    path: {sqlite3_path}
+  leveldb: 
+    dir: ~/.ndn/ndn-python-repo/leveldb/
+  mongodb:
+    db: test_python_repo
+    collection: ndn_data
+    uri: mongodb://127.0.0.1:27017/
 tcp_bulk_insert:
-  addr: '0.0.0.0'
-  port: '{port}'
+  addr: 0.0.0.0
+  port: {port}
   register_prefix: True
   prefixes:
   - /test
 logging_config:
-  level: 'INFO' 
+  level: INFO 
 """
 
 
@@ -67,13 +73,15 @@ class RepoTestSuite(object):
                 print('Cleaning up tmp file:', file)
                 os.remove(file)
 
-    def create_tmp_file(self, size_bytes=4096):
+    @staticmethod
+    def create_tmp_file(size_bytes=4096):
         tmp_file_path = os.path.join(tempfile.mkdtemp(), 'tempfile')
         with open(tmp_file_path, 'wb') as f:
             f.write(os.urandom(size_bytes))
         return tmp_file_path
 
-    def create_tmp_cfg(self):
+    @staticmethod
+    def create_tmp_cfg():
         tmp_cfg_path = os.path.join(tempfile.mkdtemp(), 'ndn-python-repo.cfg')
         with open(tmp_cfg_path, 'w') as f:
             f.write(inline_cfg)
@@ -306,24 +314,24 @@ class TestNoneMetaInfo(RepoTestSuite):
         self.app.shutdown()
 
 
-# Notes: The Github Actions failed this test case because of InterestNack.
-#        However we could not reproduce the failure.
+# Notes: The GitHub Actions failed this test case because of InterestNack.
+#        However, we could not reproduce the failure.
 #        Since we do not have sufficient understanding of the behavior, let
 #        us temporarily abandon this test case.
-#        We need to gain better knowledge on this in future.
+#        We need to gain better knowledge on this in the future.
 #
 # class TestTcpBulkInsert(RepoTestSuite):
 #     async def run(self):
 #         await aio.sleep(2)  # wait for repo to startup
-
+#
 #         reader, writer = await aio.open_connection('127.0.0.1', port)
-
+#
 #         # insert data '/test/0'
 #         writer.write(b'\x06?\x07\t\x08\x04test\x08\x010\x14\x03\x18\x01\x00\x15\x06foobar'
 #                      b'\x16\x03\x1b\x01\x00\x17 \x94?\\\xae\x99\xd5\xd6\xa5\x18\xac\x00'
 #                      b'\xe3\xcaX\x82\x972,\xf1\xebUQ\xa5I%\xb3\xd5\xac\xcc\xc6\x80Q')
 #         writer.close()
-
+#
 #         # content should be 'foobar'
 #         _, _, content = await self.app.express_interest(Name.from_str('/test/0'))
 #         assert content.tobytes().decode() == 'foobar'

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -26,7 +26,7 @@ repo_config:
   repo_name: {repo_name}
   register_root: {register_root}
 db_config:
-  db_type: leveldb
+  db_type: sqlite3
   sqlite3:
     path: {sqlite3_path}
   leveldb: 

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -1,10 +1,6 @@
-import abc
-import os
-import sys
 import asyncio as aio
 from ndn.encoding import Name
-from ndn_python_repo.storage import *
-import pytest
+from ndn_python_repo.storage import SqliteStorage
 import time
 
 
@@ -65,7 +61,7 @@ class StorageTestFixture(object):
         StorageTestFixture.storage.put_data_packet(Name.from_str('/test_freshness_period/1'), data_bytes_in)
         data_bytes_out = StorageTestFixture.storage.get_data_packet(Name.from_str('/test_freshness_period/1'), 
             must_be_fresh=True)
-        assert data_bytes_out == None
+        assert data_bytes_out is None
 
     @staticmethod
     def _test_freshness_period_again():
@@ -91,9 +87,9 @@ class StorageTestFixture(object):
             can_be_prefix=True)
         data_bytes_out3 = StorageTestFixture.storage.get_data_packet(Name.from_str('/test_get_prefi'),
             can_be_prefix=True)
-        assert data_bytes_out1 == None
+        assert data_bytes_out1 is None
         assert data_bytes_out2 == data_bytes_in
-        assert data_bytes_out3 == None  # should be None because the last name component doesn't match
+        assert data_bytes_out3 is None  # should be None because the last name component doesn't match
     
     @staticmethod
     def _test_put_batch():


### PR DESCRIPTION
Lots of code cleanup:

- change '== None' to 'is None' and '!= None' to 'is not None'
- simplify compound conditionals
- remove redundant parenthesis 
- spelling/grammar
- rename loop variable to not shadow existing variables
- remove unneeded imports
- change imported types into builtin
- merge duplicated code from command handles into a function in the command handle base class
- update doxygen docs
- add "fixme:" where errors should occur but don't
- add "fixme:" for unused function parameters
- remove unused variables
- rename camelCase variables
- remove 'self' and make functions static if they are static
- add mongodb and leveldb to the integration test configuration
- integration test now uses leveldb (we already have tests for sqlite3 in tests/storage_test.py, so this will just provide more coverage)
