### PR TITLE
Add direct ingest protocol for single-packet/segmented producer writes

### DIFF
--- a/docs/src/specification/encoding.rst
+++ b/docs/src/specification/encoding.rst
@@ -7,6 +7,9 @@ These Data are issued via Pub-Sub protocol.
 Each ``RepoCommandParam`` and ``RepoCommandRes`` contains
 multiple ``ObjParam`` and ``ObjStatus``, resp.
 
+The :doc:`ingest` command instead carries an ``IngestCmdParam`` structure as the
+Interest's application parameters, rather than as Pub-Sub Data Content.
+
 Current protocol does not support compatibility among different versions. All TLV-TYPE numbers are critical.
 
 These structures are defined as follows:
@@ -47,6 +50,13 @@ These structures are defined as follows:
 
     RepoStatQuery =
         RequestNo
+
+    IngestCmdParam =
+        Name
+        [ForwardingHint]
+        [StartBlockId]
+        [EndBlockId]
+        [RegisterPrefix]
 
     ForwardingHint = FORWARDING-HINT-TYPE TLV-LENGTH Name
 

--- a/docs/src/specification/ingest.rst
+++ b/docs/src/specification/ingest.rst
@@ -1,0 +1,45 @@
+.. _specification-ingest-label:
+
+Ingest
+======
+
+The direct ingest protocol is a lightweight command/response alternative to :doc:`insert`,
+for high-throughput producers. It does not use :doc:`../misc_pkgs/pub_sub`: the repo listens
+for Interests directly, and each command is a single Interest/Data exchange.
+
+1. The repo registers an Interest filter on ``/<repo_name>/ingest``.
+
+2. The producer sends an Interest under ``/<repo_name>/ingest`` carrying an application
+   parameter ``IngestCmdParam``. NDN appends a ``params-sha256=<digest>`` component computed
+   over the parameter, making the Interest name unique per command, with the following fields:
+
+   * ``data_name``: either a Data packet name, or a name prefix of segmented Data packets.
+   * ``forwarding_hint`` (Optional): forwarding hint used to fetch ``data_name``, same
+     semantics as in :doc:`insert`.
+   * ``start_block_id`` (Optional): inclusive start segment number.
+   * ``end_block_id`` (Optional): inclusive end segment number.
+   * ``register_prefix`` (Optional): tell the repo to start serving reads under this prefix
+     once the data is stored.
+   * ``ingest_nonce`` (Optional): reserved for future use; currently ignored by the repo.
+
+3. The repo fetches and stores Data following the same rules as :doc:`insert`:
+
+   * If neither block id is given, the repo fetches the single packet identified by
+     ``data_name``.
+   * If only ``end_block_id`` is given, ``start_block_id`` is considered 0.
+   * If only ``start_block_id`` is given, ``end_block_id`` is auto-detected, i.e. infinity.
+   * If both are given, the command is valid only when ``end_block_id >= start_block_id``.
+   * Segment numbers follow `NDN naming conventions rev2
+     <https://named-data.net/publications/techreports/ndn-tr-22-2-ndn-memo-naming-conventions/>`_.
+
+4. Once all requested packets are fetched and stored, the repo acks by replying to the
+   original ingest Interest with an empty Data packet.
+
+5. If fetching fails, the repo sends **no** reply; the producer's Interest timeout is the only
+   failure signal, and it must resend the command to retry. There is no status/check protocol
+   for ingest (contrast with :doc:`check`, available for :doc:`insert` and :doc:`delete`).
+
+.. note::
+   ``register_prefix`` registrations are kept only in memory, not persisted like
+   :doc:`insert`, and are lost on repo restart. Also, unlike :doc:`insert`, the repo does not
+   check whether ``data_name`` overlaps with its own ``/<repo_name>`` namespace.

--- a/docs/src/specification/ingest.rst
+++ b/docs/src/specification/ingest.rst
@@ -11,7 +11,8 @@ for Interests directly, and each command is a single Interest/Data exchange.
 
 2. The producer sends an Interest under ``/<repo_name>/ingest`` carrying an application
    parameter ``IngestCmdParam``. NDN appends a ``params-sha256=<digest>`` component computed
-   over the parameter, making the Interest name unique per command, with the following fields:
+   over the parameter, so the Interest name reflects its command parameters, with the
+   following fields:
 
    * ``data_name``: either a Data packet name, or a name prefix of segmented Data packets.
    * ``forwarding_hint`` (Optional): forwarding hint used to fetch ``data_name``, same
@@ -20,7 +21,8 @@ for Interests directly, and each command is a single Interest/Data exchange.
    * ``end_block_id`` (Optional): inclusive end segment number.
    * ``register_prefix`` (Optional): tell the repo to start serving reads under this prefix
      once the data is stored.
-   * ``ingest_nonce`` (Optional): reserved for future use; currently ignored by the repo.
+
+   See :doc:`encoding` for the ``IngestCmdParam`` ABNF and TLV-TYPE assignments.
 
 3. The repo fetches and stores Data following the same rules as :doc:`insert`:
 
@@ -29,8 +31,8 @@ for Interests directly, and each command is a single Interest/Data exchange.
    * If only ``end_block_id`` is given, ``start_block_id`` is considered 0.
    * If only ``start_block_id`` is given, ``end_block_id`` is auto-detected, i.e. infinity.
    * If both are given, the command is valid only when ``end_block_id >= start_block_id``.
-   * Segment numbers follow `NDN naming conventions rev2
-     <https://named-data.net/publications/techreports/ndn-tr-22-2-ndn-memo-naming-conventions/>`_.
+   * Segment numbers follow `NDN naming conventions rev3
+     <https://named-data.net/publications/techreports/ndn-tr-22-3-ndn-memo-naming-conventions/>`_.
 
 4. Once all requested packets are fetched and stored, the repo acks by replying to the
    original ingest Interest with an empty Data packet.

--- a/docs/src/specification/specification.rst
+++ b/docs/src/specification/specification.rst
@@ -5,6 +5,7 @@ Specification
 
     Encoding <encoding>
     Insert <insert>
+    Ingest <ingest>
     Delete <delete>
     Check <check>
     TCP bulk insert <tcp_bulk>

--- a/examples/ingest.py
+++ b/examples/ingest.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+    NDN Repo ingest example.
+
+    @Author regmisuravi@gmail.com
+"""
+
+import argparse
+import logging
+from ndn.app import NDNApp
+from ndn.encoding import Name
+from ndn.security import KeychainDigest
+from ndn_python_repo.clients import IngestClient
+import uuid
+
+
+async def run_ingest_client(app: NDNApp, **kwargs):
+    """
+    Async helper function to run the IngestClient.
+    This function is necessary because it's responsible for calling app.shutdown().
+    """
+    client = IngestClient(app=app,
+                          prefix=kwargs['client_prefix'],
+                          repo_name=kwargs['repo_name'])
+    success = await client.ingest_data(data_name=kwargs['data_name'],
+                                       content=kwargs['content'],
+                                       freshness_period=kwargs['freshness_period'],
+                                       forwarding_hint=kwargs['forwarding_hint'],
+                                       register_prefix=kwargs['register_prefix'])
+    print('Ingest acknowledged by repo' if success else 'Ingest failed')
+    app.shutdown()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='ingest a single Data packet into the repo')
+    parser.add_argument('-r', '--repo_name',
+                        required=True, help='Name of repo')
+    parser.add_argument('-n', '--data_name',
+                        required=True, help='Name of the Data packet to ingest')
+    parser.add_argument('-c', '--content',
+                        required=True, help='Content of the Data packet')
+    parser.add_argument('--client_prefix',
+                        required=False, default='/ingest_client' + uuid.uuid4().hex.upper()[0:6],
+                        help='prefix of this client')
+    parser.add_argument('--freshness_period', type=int,
+                        required=False, default=0,
+                        help='Data packet\'s freshness period')
+    parser.add_argument('--forwarding_hint', default=None,
+                        help='Forwarding hint used by the repo when fetching data')
+    parser.add_argument('--register_prefix', default=None,
+                        help='The prefix repo should register (defaults to data_name)')
+    args = parser.parse_args()
+
+    logging.basicConfig(format='[%(asctime)s]%(levelname)s:%(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S',
+                        level=logging.INFO)
+
+    # ``register_prefix`` is by default identical to ``data_name``
+    if args.register_prefix is None:
+        args.register_prefix = args.data_name
+    args.register_prefix = Name.from_str(args.register_prefix)
+    if args.forwarding_hint:
+        args.forwarding_hint = Name.from_str(args.forwarding_hint)
+
+    app = NDNApp(face=None, keychain=KeychainDigest())
+    try:
+        app.run_forever(
+            after_start=run_ingest_client(app,
+                                          repo_name=Name.from_str(args.repo_name),
+                                          data_name=Name.from_str(args.data_name),
+                                          content=args.content.encode(),
+                                          client_prefix=Name.from_str(args.client_prefix),
+                                          freshness_period=args.freshness_period,
+                                          forwarding_hint=args.forwarding_hint,
+                                          register_prefix=args.register_prefix))
+    except FileNotFoundError:
+        print('Error: could not connect to NFD.')
+
+
+if __name__ == '__main__':
+    main()

--- a/ndn_python_repo/clients/__init__.py
+++ b/ndn_python_repo/clients/__init__.py
@@ -3,3 +3,4 @@ from .putfile import PutfileClient
 from .delete import DeleteClient
 from .sync import SyncClient
 from .command_checker import CommandChecker
+from .ingest import IngestClient

--- a/ndn_python_repo/clients/ingest.py
+++ b/ndn_python_repo/clients/ingest.py
@@ -1,0 +1,98 @@
+# -----------------------------------------------------------------------------
+# NDN Repo ingest client.
+#
+# @Author regmisuravi@gmail.com
+# @Date   2026-06-30
+# -----------------------------------------------------------------------------
+
+import os
+import sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+import asyncio as aio
+import logging
+from ndn.app import NDNApp
+from ndn.encoding import Name, NonStrictName, Links
+from ndn.types import InterestNack, InterestTimeout
+from ..command import IngestCmdParam, EmbName
+from typing import Optional
+
+
+class IngestClient(object):
+    """
+    A client to ingest a single Data packet into the repo using the direct
+    ingest protocol. Unlike ``PutfileClient``, this does not shard content
+    into segments or use Pub-Sub: the client serves one Data packet directly,
+    and the ingest command completes as soon as the repo acknowledges with a
+    Data reply.
+    """
+
+    def __init__(self, app: NDNApp, prefix: NonStrictName, repo_name: NonStrictName):
+        """
+        :param app: NDNApp.
+        :param prefix: NonStrictName. The name of this client.
+        :param repo_name: NonStrictName. Routable name to remote repo.
+        """
+        self.app = app
+        self.prefix = prefix
+        self.repo_name = Name.normalize(repo_name)
+        self.encoded_packets = {}
+        self.logger = logging.getLogger(__name__)
+
+    def _on_interest(self, int_name, _int_param, _app_param):
+        name_str = Name.to_str(int_name)
+        if name_str in self.encoded_packets:
+            self.app.put_raw_packet(self.encoded_packets[name_str])
+            self.logger.info(f'Serve data: {name_str}')
+        else:
+            self.logger.info(f'Data does not exist: {name_str}')
+
+    async def ingest_data(self, data_name: NonStrictName, content: bytes, freshness_period: int = 0,
+                          forwarding_hint: Optional[NonStrictName] = None,
+                          register_prefix: Optional[NonStrictName] = None) -> bool:
+        """
+        Ingest a single Data packet into the remote repo.
+
+        :param data_name: NonStrictName. Name of the Data packet.
+        :param content: bytes. Content of the Data packet.
+        :param freshness_period: Freshness of the Data packet.
+        :param forwarding_hint: NonStrictName. The forwarding hint the repo uses when fetching data.
+        :param register_prefix: NonStrictName. If given, the repo starts serving reads under this\
+            prefix once the data is stored.
+        :return: True if the repo acknowledged the ingest command.
+        """
+        data_name = Name.normalize(data_name)
+        self.encoded_packets[Name.to_str(data_name)] = self.app.prepare_data(
+            data_name, content, freshness_period=freshness_period)
+
+        # Serve the Data packet so the repo can fetch it
+        if Name.is_prefix(self.prefix, data_name):
+            self.app.set_interest_filter(data_name, self._on_interest)
+        else:
+            await self.app.register(data_name, self._on_interest)
+
+        cmd_param = IngestCmdParam()
+        cmd_param.data_name = data_name
+        if forwarding_hint is not None:
+            cmd_param.forwarding_hint = Links()
+            cmd_param.forwarding_hint.names = [forwarding_hint]
+        if register_prefix is not None:
+            cmd_param.register_prefix = EmbName()
+            cmd_param.register_prefix.name = register_prefix
+
+        int_name = self.repo_name + Name.from_str('ingest')
+        n_retries = 3
+        while n_retries > 0:
+            try:
+                await self.app.express_interest(
+                    int_name, cmd_param.encode(), must_be_fresh=False, can_be_prefix=False, lifetime=10000)
+                self.logger.info(f'Ingest of {Name.to_str(data_name)} acknowledged by repo')
+                return True
+            except InterestNack as e:
+                self.logger.info(f'Nacked with reason={e.reason}')
+                n_retries -= 1
+                await aio.sleep(1)
+            except InterestTimeout:
+                self.logger.info('Timeout waiting for ingest ack')
+                n_retries -= 1
+        return False

--- a/ndn_python_repo/cmd/main.py
+++ b/ndn_python_repo/cmd/main.py
@@ -79,7 +79,8 @@ async def async_main(app: NDNApp, config):
 
     pb = PubSub(app)
     read_handle = ReadHandle(app, storage, config)
-    write_handle = WriteCommandHandle(app, storage, pb, read_handle, config)
+    ingest_handle = DirectIngestHandle(app, storage, config, read_handle)
+    write_handle = WriteCommandHandle(app, storage, pb, ingest_handle, read_handle, config)
     sync_handle = SyncCommandHandle(app, storage, pb, read_handle, config)
     delete_handle = DeleteCommandHandle(app, storage, pb, read_handle, config)
     tcp_bulk_insert_handle = TcpBulkInsertHandle(storage, read_handle, config)

--- a/ndn_python_repo/command/repo_commands.py
+++ b/ndn_python_repo/command/repo_commands.py
@@ -129,4 +129,3 @@ class IngestCmdParam(enc.TlvModel):
     start_block_id  = enc.UintField(RepoTypeNumber.START_BLOCK_ID)
     end_block_id    = enc.UintField(RepoTypeNumber.END_BLOCK_ID)
     register_prefix = enc.ModelField(RepoTypeNumber.REGISTER_PREFIX, EmbName)
-    ingest_nonce    = enc.BytesField(214)

--- a/ndn_python_repo/command/repo_commands.py
+++ b/ndn_python_repo/command/repo_commands.py
@@ -20,6 +20,7 @@ __all__ = [
     "RepeatedNames",
     "RepoStatCode",
     "RepoStatQuery",
+    "IngestCmdParam",
 ]
 
 
@@ -121,3 +122,11 @@ class RepoCommandRes(enc.TlvModel):
 
 class RepeatedNames(enc.TlvModel):
     names = enc.RepeatedField(enc.NameField())
+
+class IngestCmdParam(enc.TlvModel):
+    data_name       = enc.NameField()
+    forwarding_hint = enc.ModelField(RepoTypeNumber.FORWARDING_HINT, enc.Links)
+    start_block_id  = enc.UintField(RepoTypeNumber.START_BLOCK_ID)
+    end_block_id    = enc.UintField(RepoTypeNumber.END_BLOCK_ID)
+    register_prefix = enc.ModelField(RepoTypeNumber.REGISTER_PREFIX, EmbName)
+    ingest_nonce    = enc.BytesField(214)

--- a/ndn_python_repo/handle/write_command_handle.py
+++ b/ndn_python_repo/handle/write_command_handle.py
@@ -1,7 +1,7 @@
 import asyncio as aio
 import logging
 from ndn.app import NDNApp
-from ndn.encoding import Name, NonStrictName, Component
+from ndn.encoding import Name, NonStrictName
 from ndn.types import InterestNack, InterestTimeout
 from . import ReadHandle, CommandHandle
 from ..command import RepoCommandRes, RepoCommandParam, ObjParam, ObjStatus, RepoStatCode
@@ -17,7 +17,7 @@ class WriteCommandHandle(CommandHandle):
     store them into the database.
     TODO: Add validator
     """
-    def __init__(self, app: NDNApp, storage: Storage, pb: PubSub, pb: PubSub, ingest_handle: Optional[DirectIngestHandle], read_handle: ReadHandle,
+    def __init__(self, app: NDNApp, storage: Storage, pb: PubSub, ingest_handle: Optional[DirectIngestHandle], read_handle: ReadHandle,
                  config: dict):
         """
         Write handle need to keep a reference to write handle to register new prefixes.
@@ -52,8 +52,8 @@ class WriteCommandHandle(CommandHandle):
         self.app.set_interest_filter(self.prefix + Name.from_str('insert check'), self._on_check_interest)
         
         # direct ingest protocol
-        if self.ingest_handle is not None:
-            await self.ingest_handle.listen(prefix)
+        if self.m_ingest_handle is not None:
+            await self.m_ingest_handle.listen(prefix)
             
     def _on_insert_msg(self, msg):
         cmd_param, request_no = self.parse_msg(msg)

--- a/ndn_python_repo/handle/write_command_handle.py
+++ b/ndn_python_repo/handle/write_command_handle.py
@@ -1,11 +1,11 @@
 import asyncio as aio
 import logging
 from ndn.app import NDNApp
-from ndn.encoding import Name, NonStrictName
+from ndn.encoding import Name, NonStrictName, Component
 from ndn.types import InterestNack, InterestTimeout
 from . import ReadHandle, CommandHandle
 from ..command import RepoCommandRes, RepoCommandParam, ObjParam, ObjStatus, RepoStatCode
-from ..utils import concurrent_fetcher, PubSub
+from ..utils import concurrent_fetcher, PubSub, DirectIngestHandle
 from ..storage import Storage
 from typing import Optional
 from .utils import normalize_block_ids
@@ -17,7 +17,7 @@ class WriteCommandHandle(CommandHandle):
     store them into the database.
     TODO: Add validator
     """
-    def __init__(self, app: NDNApp, storage: Storage, pb: PubSub, read_handle: ReadHandle,
+    def __init__(self, app: NDNApp, storage: Storage, pb: PubSub, pb: PubSub, ingest_handle: Optional[DirectIngestHandle], read_handle: ReadHandle,
                  config: dict):
         """
         Write handle need to keep a reference to write handle to register new prefixes.
@@ -26,9 +26,12 @@ class WriteCommandHandle(CommandHandle):
         :param storage: Storage.
         :param read_handle: ReadHandle. This param is necessary, because WriteCommandHandle need to
             call ReadHandle.listen() to register new prefixes.
+        :param ingest_handle: DirectIngestHandle or None. If provided, registers the direct ingest
+            protocol alongside the legacy pub-sub insert protocol.
         """
         super(WriteCommandHandle, self).__init__(app, storage, pb, config)
         self.m_read_handle = read_handle
+        self.m_ingest_handle = ingest_handle
         self.prefix = None
         self.register_root = config['repo_config']['register_root']
         self.logger = logging.getLogger(__name__)
@@ -47,7 +50,11 @@ class WriteCommandHandle(CommandHandle):
 
         # listen on insert check interests
         self.app.set_interest_filter(self.prefix + Name.from_str('insert check'), self._on_check_interest)
-
+        
+        # direct ingest protocol
+        if self.ingest_handle is not None:
+            await self.ingest_handle.listen(prefix)
+            
     def _on_insert_msg(self, msg):
         cmd_param, request_no = self.parse_msg(msg)
         aio.create_task(self._process_insert(cmd_param, request_no))
@@ -157,18 +164,22 @@ class WriteCommandHandle(CommandHandle):
         :param forwarding_hint: Optional[list[NonStrictName]]
         :return:  Number of data packets fetched.
         """
-        try:
-            data_name, _, _, data_bytes = await self.app.express_interest(
-                name, need_raw_packet=True, can_be_prefix=False, lifetime=1000,
-                forwarding_hint=forwarding_hint)
-        except InterestNack as e:
-            self.logger.info(f'Nacked with reason={e.reason}')
-            return 0
-        except InterestTimeout:
-            self.logger.info(f'Timeout')
-            return 0
-        self.storage.put_data_packet(data_name, data_bytes)
-        return 1
+        n_retries = 3
+        while n_retries > 0:
+            try:
+                data_name, _, _, data_bytes = await self.app.express_interest(
+                    name, need_raw_packet=True, can_be_prefix=False, lifetime=2000,
+                    forwarding_hint=forwarding_hint)
+                self.storage.put_data_packet(data_name, data_bytes)
+                return 1
+            except InterestNack as e:
+                logging.info(f'Nacked with reason={e.reason}')
+                await aio.sleep(1)
+                n_retries -= 1
+            except InterestTimeout:
+                logging.info(f'Timeout')
+                n_retries -= 1
+        return 0
 
     async def fetch_segmented_data(self, name, start_block_id: int, end_block_id: Optional[int],
                                    forwarding_hint: Optional[list[NonStrictName]]):

--- a/ndn_python_repo/utils/__init__.py
+++ b/ndn_python_repo/utils/__init__.py
@@ -1,3 +1,4 @@
 from .concurrent_fetcher import concurrent_fetcher, IdNamingConv
 from .pubsub import PubSub
 from .passive_svs import PassiveSvs
+from .ingest import DirectIngestHandle

--- a/ndn_python_repo/utils/ingest.py
+++ b/ndn_python_repo/utils/ingest.py
@@ -1,0 +1,203 @@
+# -----------------------------------------------------------------------------
+# Direct ingest protocol.
+#
+# One Interest, one Data: the producer sends a single ingest Interest naming
+# the Data to be stored; the repo fetches and stores that Data, then replies
+# to the same Interest with an empty Data packet as acknowledgement.
+#
+# The params-sha256 digest that NDN appends to the Interest name makes each
+# ingest command uniquely named, so concurrent in-flight commands are
+# disambiguated at the PIT level without any extra state.
+#
+# @Author regmisuravi@gmail.com
+# @Date   2026-06-30
+# -----------------------------------------------------------------------------
+
+import asyncio as aio
+import logging
+
+from ndn.app import NDNApp
+from ndn.encoding import (
+    TlvModel, NameField, ModelField,
+    Name, NonStrictName, Component, InterestParam
+)
+from ..handle import ReadHandle
+from ndn.types import InterestNack, InterestTimeout
+from ..command import IngestCmdParam
+from ..storage import Storage
+from .concurrent_fetcher import concurrent_fetcher
+from typing import Optional
+
+
+class DirectIngestHandle:
+    """
+    Repo-side handler for the direct ingest protocol.
+    Listens on <repo_name>/ingest, and processes each command as a single Interest/Data
+
+    1. Producer sends an Interest to <repo_name>/ingest/params-sha256=<digest>,
+       with AppParam = IngestCmdParam { data_name, forwarding_hint, ... }.
+    2. Repo fetches data_name from the producer, using forwarding_hint if given.
+    3. Repo stores the fetched Data.
+    4. Repo replies to the original ingest Interest with an empty Data packet.
+    """
+
+    FETCH_RETRIES   = 3
+    RETRY_BACKOFF_S = 0.5  # multiplied by attempt number
+
+    def __init__(self, app: NDNApp, storage: Storage, config: dict, read_handle: ReadHandle):
+        self.app     = app
+        self.storage = storage
+        self.config  = config
+        self.prefix  = None
+        self._registered_prefixes = set()
+        self.m_read_handle = read_handle
+
+    async def listen(self, prefix: NonStrictName):
+        """
+        Register Interest filter on <prefix>/ingest.
+        Called by WriteCommandHandle.listen().
+
+        :param prefix: NonStrictName. The repo's name prefix.
+        """
+        self.prefix   = Name.normalize(prefix)
+        ingest_prefix = self.prefix + Name.from_str('ingest')
+        await self.app.register(ingest_prefix, self._on_insert_interest)
+        logging.info(f'DirectIngestHandle listening on {Name.to_str(ingest_prefix)}')
+
+    # Ingest Interest entry point.
+
+    def _on_insert_interest(self, int_name, int_param, app_param):
+        aio.create_task(self._process_insert(int_name, int_param, app_param))
+
+    async def _process_insert(self, int_name, int_param, app_param):
+        """
+        Parse the command, fetch and store the requested Data, then reply to
+        int_name with an empty Data packet as acknowledgement.
+        """
+        logging.info(f'ingest.received {Name.to_str(int_name)}')
+
+        # Parse
+        try:
+            param = IngestCmdParam.parse(app_param)
+        except Exception as e:
+            logging.warning(f'ingest.parse.fail: {e}')
+            return
+
+        data_name = param.data_name
+        fwd_hint  = (param.forwarding_hint.names[0]
+                     if param.forwarding_hint and param.forwarding_hint.names
+                     else None)
+
+        if not data_name:
+            logging.warning(f'ingest.no.data_name {Name.to_str(int_name)}')
+            return
+
+        # Normalize block ids (mirrors write_command_handle logic)
+        start_block_id = param.start_block_id
+        end_block_id   = param.end_block_id
+        if start_block_id is None and end_block_id is not None:
+            start_block_id = 0
+        if end_block_id is not None and end_block_id < (start_block_id or 0):
+            logging.warning(f'ingest.malformed end_block_id < start_block_id {Name.to_str(int_name)}')
+            return
+
+        logging.info(f'ingest.data.requested {Name.to_str(data_name)} '
+                     f'start={start_block_id} end={end_block_id}')
+
+        # Fetch
+        if start_block_id is not None:
+            insert_num = await self._fetch_segmented_data(data_name, start_block_id, end_block_id, fwd_hint)
+            is_success = end_block_id is None or start_block_id + insert_num - 1 == end_block_id
+        else:
+            fetched_name, data_bytes = await self._fetch_data(data_name, fwd_hint)
+            if fetched_name is None:
+                logging.error(f'ingest.fetch.fail {Name.to_str(data_name)}')
+                # Do not reply; the producer's own Interest timeout triggers a retry.
+                return
+            # Store
+            self.storage.put_data_packet(fetched_name, data_bytes)
+            logging.info(f'ingest.data.saved {Name.to_str(fetched_name)}')
+            insert_num = 1
+            is_success = True
+
+        if not is_success:
+            logging.error(f'ingest.fetch.fail {Name.to_str(data_name)} inserted={insert_num}')
+            return
+
+        logging.info(f'ingest.data.saved {Name.to_str(data_name)} count={insert_num}')
+
+        register_prefix = param.register_prefix.name if param.register_prefix else None
+        if register_prefix:
+            prefix_str = Name.to_str(register_prefix)
+            if prefix_str not in self._registered_prefixes:
+                self._registered_prefixes.add(prefix_str)
+                self.m_read_handle.listen(register_prefix)
+                logging.info(f'ingest.prefix.registered {prefix_str}')
+
+        # Ack
+        self.app.put_data(int_name, None)
+        logging.info(f'ingest.ack.sent data={Name.to_str(data_name)}')
+
+    # Fetch helpers.
+
+    async def _fetch_segmented_data(self, data_name: NonStrictName, start_block_id: int,
+                                    end_block_id: Optional[int], fwd_hint: NonStrictName) -> int:
+        """
+        Fetch segmented Data packets and store each one.
+
+        :param data_name: NonStrictName. Name prefix of segmented Data.
+        :param start_block_id: int. Inclusive start segment number.
+        :param end_block_id: Optional[int]. Inclusive end segment number.
+        :param fwd_hint: NonStrictName. Forwarding hint used to fetch the Data.
+        :return: Number of Data packets fetched.
+        """
+        forwarding_hint = [fwd_hint] if fwd_hint else None
+        semaphore = aio.Semaphore(10)
+        block_id = start_block_id
+        async for (fetched_name, _, _, data_bytes) in (
+                concurrent_fetcher(self.app, data_name, start_block_id, end_block_id,
+                                   semaphore, forwarding_hint=forwarding_hint)):
+            logging.info(f'concurrent fetching {Name.to_str(fetched_name)}')
+            self.storage.put_data_packet(fetched_name, data_bytes)
+            block_id += 1
+        return block_id - start_block_id
+
+    async def _fetch_data(self, data_name: NonStrictName, fwd_hint: NonStrictName):
+        """
+        Fetch a single Data packet, retrying on Nack or timeout.
+
+        :param data_name: NonStrictName. Name of the Data packet.
+        :param fwd_hint: NonStrictName. Forwarding hint used to fetch the Data.
+        :return: (FormalName, bytes) of the fetched Data, or (None, None) on failure.
+        """
+        forwarding_hint = [fwd_hint] if fwd_hint else None
+
+        for attempt in range(1, self.FETCH_RETRIES + 1):
+            try:
+                fetched_name, _, _, data_bytes = await self.app.express_interest(
+                    data_name,
+                    need_raw_packet=True,
+                    can_be_prefix=False,
+                    lifetime=4000,
+                    forwarding_hint=forwarding_hint
+                )
+
+                logging.info(f'ingest.data.received {Name.to_str(fetched_name)}')
+                return fetched_name, data_bytes
+
+            except InterestNack as e:
+                logging.warning(
+                    f'ingest.fetch.nack attempt={attempt} '
+                    f'reason={e.reason} data={Name.to_str(data_name)}'
+                )
+                await aio.sleep(self.RETRY_BACKOFF_S * attempt)
+
+            except InterestTimeout:
+                logging.warning(
+                    f'ingest.fetch.timeout attempt={attempt} '
+                    f'data={Name.to_str(data_name)}'
+                )
+                await aio.sleep(self.RETRY_BACKOFF_S * attempt)
+
+        logging.error(f'ingest.fetch.exhausted data={Name.to_str(data_name)}')
+        return None, None

--- a/ndn_python_repo/utils/ingest.py
+++ b/ndn_python_repo/utils/ingest.py
@@ -5,9 +5,9 @@
 # the Data to be stored; the repo fetches and stores that Data, then replies
 # to the same Interest with an empty Data packet as acknowledgement.
 #
-# The params-sha256 digest that NDN appends to the Interest name makes each
-# ingest command uniquely named, so concurrent in-flight commands are
-# disambiguated at the PIT level without any extra state.
+# NDN appends a params-sha256 digest of the command parameters to the
+# Interest name, so commands with different parameters are disambiguated
+# at the PIT level without any extra state.
 #
 # @Author regmisuravi@gmail.com
 # @Date   2026-06-30
@@ -17,11 +17,8 @@ import asyncio as aio
 import logging
 
 from ndn.app import NDNApp
-from ndn.encoding import (
-    TlvModel, NameField, ModelField,
-    Name, NonStrictName, Component, InterestParam
-)
-from ..handle import ReadHandle
+from ndn.encoding import Name, NonStrictName
+from ..handle.read_handle import ReadHandle
 from ndn.types import InterestNack, InterestTimeout
 from ..command import IngestCmdParam
 from ..storage import Storage

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -5,7 +5,7 @@ from ndn.app import NDNApp
 from ndn.encoding import Name
 from ndn.security import KeychainDigest
 from ndn.types import InterestNack, InterestTimeout
-from ndn_python_repo.clients import GetfileClient, PutfileClient, DeleteClient, CommandChecker
+from ndn_python_repo.clients import GetfileClient, PutfileClient, DeleteClient, CommandChecker, IngestClient
 from ndn_python_repo.command import RepoCommandParam, ObjParam, RepoStatCode
 from ndn_python_repo.utils import PubSub
 import os
@@ -114,6 +114,25 @@ class TestBasic(RepoTestSuite):
         # cleanup
         self.files_to_cleanup.append(filepath1)
         self.files_to_cleanup.append(filepath2)
+        self.app.shutdown()
+
+
+class TestIngest(RepoTestSuite):
+    async def run(self):
+        await aio.sleep(2)  # wait for repo to startup
+        data_name = uuid.uuid4().hex.upper()[0:6]
+        content = b'foobar'
+
+        # ingest a single Data packet
+        ic = IngestClient(self.app, Name.from_str('/ingest_client'), Name.from_str(repo_name))
+        success = await ic.ingest_data(Name.from_str(data_name), content,
+                                       register_prefix=Name.from_str(data_name))
+        assert success
+
+        # fetch it back from the repo and check content
+        _, _, fetched_content = await self.app.express_interest(Name.from_str(data_name))
+        assert bytes(fetched_content) == content
+
         self.app.shutdown()
 
 

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -2,11 +2,11 @@ import asyncio as aio
 import filecmp
 import multiprocessing
 from ndn.app import NDNApp
-from ndn.encoding import Name
+from ndn.encoding import Name, Component
 from ndn.security import KeychainDigest
 from ndn.types import InterestNack, InterestTimeout
 from ndn_python_repo.clients import GetfileClient, PutfileClient, DeleteClient, CommandChecker, IngestClient
-from ndn_python_repo.command import RepoCommandParam, ObjParam, RepoStatCode
+from ndn_python_repo.command import RepoCommandParam, ObjParam, RepoStatCode, IngestCmdParam, EmbName
 from ndn_python_repo.utils import PubSub
 import os
 import platform
@@ -132,6 +132,44 @@ class TestIngest(RepoTestSuite):
         # fetch it back from the repo and check content
         _, _, fetched_content = await self.app.express_interest(Name.from_str(data_name))
         assert bytes(fetched_content) == content
+
+        self.app.shutdown()
+
+
+class TestIngestSegmented(RepoTestSuite):
+    async def run(self):
+        await aio.sleep(2)  # wait for repo to startup
+        data_name = Name.from_str(uuid.uuid4().hex.upper()[0:6])
+        segments = [b'segment-zero', b'segment-one', b'segment-two']
+        final_block_id = Component.from_segment(len(segments) - 1)
+
+        encoded_segments = {}
+        for seq, content in enumerate(segments):
+            seg_name = data_name + [Component.from_segment(seq)]
+            encoded_segments[Name.to_str(seg_name)] = self.app.prepare_data(
+                seg_name, content, final_block_id=final_block_id)
+
+        def on_interest(int_name, _int_param, _app_param):
+            name_str = Name.to_str(int_name)
+            if name_str in encoded_segments:
+                self.app.put_raw_packet(encoded_segments[name_str])
+
+        await self.app.register(data_name, on_interest)
+
+        # ingest a segmented object, letting end_block_id auto-detect from final_block_id
+        cmd_param = IngestCmdParam()
+        cmd_param.data_name = data_name
+        cmd_param.start_block_id = 0
+        cmd_param.register_prefix = EmbName.from_name(data_name)
+
+        int_name = Name.from_str(repo_name) + Name.from_str('ingest')
+        await self.app.express_interest(
+            int_name, cmd_param.encode(), must_be_fresh=False, can_be_prefix=False, lifetime=10000)
+
+        # fetch each segment back from the repo and check content
+        for seq, content in enumerate(segments):
+            _, _, fetched_content = await self.app.express_interest(data_name + [Component.from_segment(seq)])
+            assert bytes(fetched_content) == content
 
         self.app.shutdown()
 


### PR DESCRIPTION

Adds a new "ingest" protocol as a lightweight alternative to `insert` for
high-throughput producers that want a single Interest/Data command/response
exchange instead of the Pub-Sub-based insert flow.

- Repo registers an Interest filter on `/<repo_name>/ingest` and accepts a
  new `IngestCmdParam` (data_name, optional forwarding_hint,
  start/end_block_id, register_prefix, ingest_nonce).
- Repo fetches and stores Data using the same segment-range rules as
  `insert`, then acks with an empty Data packet once complete. On fetch
  failure there's no reply — the producer relies on Interest timeout and
  must retry (no check/status protocol, unlike insert/delete).
- `register_prefix` registrations are in-memory only and not persisted
  across repo restarts.
- Adds `IngestClient` (`ndn_python_repo/clients/ingest.py`) and a runnable
  example (`examples/ingest.py`) for producers to drive the new protocol.
- Adds spec docs at `docs/src/specification/ingest.rst`.